### PR TITLE
🩹 [Actions] Safer package keys

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -17,10 +17,10 @@
         '!*.md',
       ]
 # Package labels
-📦️ config: assets: packages/assets-config/**/*
-📦️ config: browserslist: packages/browserslist-config/**/*
-📦️ config: prettier: packages/prettier-config/**/*
-📦️ config: stylelint: packages/stylelint-config/**/*
-📦️ config: typescript: packages/typescript-config/**/*
-📦️ plugin: eslint: packages/eslint-plugin/**/*
-📦️ plugin: postcss: packages/postcss-plugin/**/*
+'📦️ config: assets': 'packages/assets-config/**/*'
+'📦️ config: browserslist': 'packages/browserslist-config/**/*'
+'📦️ config: prettier': 'packages/prettier-config/**/*'
+'📦️ config: stylelint': 'packages/stylelint-config/**/*'
+'📦️ config: typescript': 'packages/typescript-config/**/*'
+'📦️ plugin: eslint': 'packages/eslint-plugin/**/*'
+'📦️ plugin: postcss': 'packages/postcss-plugin/**/*'


### PR DESCRIPTION
Realized I had a `:` in a key name.