### PR TITLE
🔧 [Actions] No need for lint task to use fetch-depth

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,8 +9,6 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - name: Setup Node 17.x
         uses: actions/setup-node@v2


### PR DESCRIPTION
I can't see why this was needed